### PR TITLE
nodelet::CMakeLists: support OpenCV 3.2 and 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ ROS wrapper for realtime object detection, localization and tracking
   * cv_bridge
   * libpcl-all
   * libpcl-all-dev
+  * ros-kinetic-opencv3
 
   Other ROS packages
   * [object_msgs](https://github.com/intel/object_msgs)
   * [opencl_caffe](https://github.com/intel/ros_opencl_caffe)
   * [object_detect_launch](https://github.com/intel/ros_object_detect_launch)
 
-  OpenCV
-  * [opencv](https://github.com/opencv/opencv) tag 3.2.0
+  NOTE: In older version of "ros-kinetic-opencv3" where OpenCV 3.2.0 was used, self-built opencv_tracking is needed. While this's no more necessary since OpenCV 3.3 integrated. Check the OpenCV version from "/opt/ros/kinetic/share/opencv3/package.xml"
   * [opencv_tracking](https://github.com/opencv/opencv_contrib) tag 3.2.0
 
 ## build and test
@@ -41,7 +41,7 @@ ROS wrapper for realtime object detection, localization and tracking
 
 ## extra running dependencies
   RGB-D camera
-  * [librealsense2](https://github.com/IntelRealSense/librealsense/tree/master) and [realsense_ros_camera](https://github.com/intel-ros/realsense/tree/2.0.1) if run with Intel RealSense D400
+  * [librealsense2 tag v2.8.1](https://github.com/IntelRealSense/librealsense/tree/v2.8.1) and [realsense_ros_camera tag 2.0.1](https://github.com/intel-ros/realsense/tree/2.0.1) if run with Intel RealSense D400
   ```
   roslaunch realsense_ros_camera rs_camera.launch enable_pointcloud:=true enable_sync:=true enable_infra1:=false enable_infra2:=false
   ```

--- a/object_analytics_nodelet/CMakeLists.txt
+++ b/object_analytics_nodelet/CMakeLists.txt
@@ -48,6 +48,8 @@ find_package(PCL 1.7 REQUIRED COMPONENTS
   filters
 )
 
+find_package(OpenCV 3.2 REQUIRED)
+
 # generate dynamic reconfigure
 generate_dynamic_reconfigure_options(
   cfg/SegmentationAlgorithms.cfg

--- a/object_analytics_nodelet/src/tracker/tracking.cpp
+++ b/object_analytics_nodelet/src/tracker/tracking.cpp
@@ -16,7 +16,6 @@
 
 #include <string>
 #include <ros/assert.h>
-#include <cv_bridge/cv_bridge.h>
 #include "object_analytics_nodelet/tracker/tracking.h"
 
 namespace object_analytics_nodelet
@@ -45,7 +44,11 @@ void Tracking::rectifyTracker(const cv::Mat& mat, const cv::Rect2d& rect)
   {
     tracker_.release();
   }
-  tracker_ = cv::Tracker::create("MIL");
+  #if CV_VERSION_MINOR == 2
+    tracker_ = cv::Tracker::create("MIL");
+  #else
+    tracker_ = cv::TrackerMIL::create();
+  #endif
   tracker_->init(mat, rect);
   rect_ = rect;
 }

--- a/object_analytics_nodelet/tests/mtest_tracking.cpp
+++ b/object_analytics_nodelet/tests/mtest_tracking.cpp
@@ -31,9 +31,11 @@ using SyncTracking = message_filters::TimeSynchronizer<sensor_msgs::Image, objec
 
 static const std::string kCvWindowName = "Object Analytics View";
 static bool received_tracks;
-static object_msgs::ObjectsInBoxesConstPtr dobjs;
+#ifdef MTEST_TRACKING_ENABLE_VIEW
+static object_msgs::ObjectsInBoxesConstPtr dobjs = nullptr;
 static ros::Duration dlatency;
 static int32_t dfps;
+#endif
 
 static void tracking_cb(const sensor_msgs::ImageConstPtr& rgb,
                         const object_analytics_msgs::TrackedObjectsConstPtr& tracks)
@@ -126,7 +128,6 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   received_tracks = false;
-  dobjs = nullptr;
 
   ros::init(argc, argv, "mtest_tracking");
   ros::NodeHandle nh;


### PR DESCRIPTION
In older version of "ros-kinetic-opencv3" where OpenCV 3.2.0 was used,
self-built opencv_tracking is needed. While this's no more necessary
since OpenCV 3.3 integrated.
Check the OpenCV version from "/opt/ros/kinetic/share/opencv3/package.xml"

Signed-off-by: Sharron LIU <sharron.liu@intel.com>