### PR TITLE
nodelet::tracking: adjust ROI before init a tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # ros_object_analytics
-ROS wrapper for realtime object detection, localization and tracking
+Object Analytics (OA) is ROS wrapper for realtime object detection, localization and tracking.
+These packages aim to provide real-time object analyses over RGB-D camera inputs, enabling ROS developer to easily create amazing robotics advanced features, like intelligent collision avoidance and semantic SLAM. It consumes [sensor_msgs::PointClould2](http://docs.ros.org/api/sensor_msgs/html/msg/PointCloud2.html) data delivered by RGB-D camera, publishing topics on [object detection](https://github.com/intel/object_msgs), [object tracking](https://github.com/intel/ros_object_analytics/tree/master/object_analytics_msgs), and [object localization](https://github.com/intel/ros_object_analytics/object_analytics_msgs) in 3D camera coordination system.
+
+OA keeps integrating with various "state-of-the-art" algorithms.
+* Object detection offload to GPU, [ros_opencl_caffe](https://github.com/intel/ros_opencl_caffe), with Yolo v2 model and [OpenCL Caffe](https://github.com/01org/caffe/wiki/clCaffe#yolo2-model-support) framework
+* Object detection offload to VPU, [ros_intel_movidius_ncs](https://github.com/intel/ros_intel_movidius_ncs), with MobileNet SSD model and Caffe framework
 
 ## compiling dependencies
   ROS packages from [ros-kinetic-desktop-full](http://wiki.ros.org/kinetic/Installation/Ubuntu)
@@ -62,7 +67,7 @@ ROS wrapper for realtime object detection, localization and tracking
 
   There are two choices for 2d detection, one is [clCaffe](https://github.com/intel/ros_opencl_caffe) another is [Movidius NCS](https://github.com/intel/ros_intel_movidius_ncs), Movidius NCS is the default, and can switch to clCaffe by appending 'detect_impl:=opencl_caffe' ros argument, like below:
   ```bash
-  roslaunch object_analytics_launch analytics.launch detect_impl:=opencl_caffe
+  roslaunch object_analytics_launch analytics.launch detect_pkg:=opencl_caffe
   ```
 
 ## published topics

--- a/object_analytics_nodelet/src/tracker/tracking.cpp
+++ b/object_analytics_nodelet/src/tracker/tracking.cpp
@@ -25,14 +25,14 @@ namespace tracker
 const int32_t Tracking::kAgeingThreshold = 16;
 
 Tracking::Tracking(int32_t tracking_id, const std::string& name, const cv::Rect2d& rect)
-  : rect_(rect), obj_name_(name), tracking_id_(tracking_id), detected_(false)
+  : tracker_(cv::Ptr<cv::Tracker>()), rect_(rect), obj_name_(name), tracking_id_(tracking_id), detected_(false)
 {
   ROS_ASSERT(tracking_id >= 0);
 }
 
 Tracking::~Tracking()
 {
-  if (!tracker_.empty())
+  if (tracker_.get())
   {
     tracker_.release();
   }
@@ -40,15 +40,15 @@ Tracking::~Tracking()
 
 void Tracking::rectifyTracker(const cv::Mat& mat, const cv::Rect2d& rect)
 {
-  if (!tracker_.empty())
+  if (tracker_.get())
   {
     tracker_.release();
   }
-  #if CV_VERSION_MINOR == 2
-    tracker_ = cv::Tracker::create("MIL");
-  #else
-    tracker_ = cv::TrackerKCF::create();
-  #endif
+#if CV_VERSION_MINOR == 2
+  tracker_ = cv::Tracker::create("MIL");
+#else
+  tracker_ = cv::TrackerMIL::create();
+#endif
   tracker_->init(mat, rect);
   rect_ = rect;
 }

--- a/object_analytics_nodelet/src/tracker/tracking_manager.cpp
+++ b/object_analytics_nodelet/src/tracker/tracking_manager.cpp
@@ -78,6 +78,15 @@ void TrackingManager::detect(const cv::Mat& mat, const object_msgs::ObjectsInBox
     }
     std::string n = dobj.object_name;
     sensor_msgs::RegionOfInterest droi = objs->objects_vector[i].roi;
+    /* some trackers do not accept an ROI beyond the size of a Mat*/
+    if (droi.x_offset + droi.width > static_cast<uint32_t>(mat.cols))
+    {
+      droi.width = mat.cols - droi.x_offset;
+    }
+    if (droi.y_offset + droi.height > static_cast<uint32_t>(mat.rows))
+    {
+      droi.height = mat.rows - droi.y_offset;
+    }
     cv::Rect2d r = cv::Rect2d(droi.x_offset, droi.y_offset, droi.width, droi.height);
     ROS_DEBUG("detected %s [%d %d %d %d] %.0f%%", n.c_str(), droi.x_offset, droi.y_offset, droi.width, droi.height,
               dobj.probability * 100);


### PR DESCRIPTION
Some trackers like MIL, do not accept an ROI beyond the size of a Mat.
ROI is adjusted before being passed to init such a tracker.

Signed-off-by: Sharron LIU <sharron.liu@intel.com>