### PR TITLE
launch: added common launch file "nodelet.launch.xml"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ OA keeps integrating with various "state-of-the-art" algorithms.
 
   Frequently used options
   * **input_points** Specify arg "input_points" for the name of the topic publishing the [sensor_msgs::PointCloud2](http://docs.ros.org/api/sensor_msgs/html/msg/PointCloud2.html) messages by RGB-D camera. Default is "/camera/depth_registered/points" (topic compliant with [ROS OpenNI launch](http://wiki.ros.org/openni_launch))
+  * **aging_th** Specifiy tracking aging threshold, number of frames since last detection to deactivate the tracking. Default is 30.
+  * **probability_th** Specify the probability threshold for tracking object. Default is "0.4".
+  ```bash
+  roslaunch object_analytics_launch analytics_movidius_ncs.launch aging_th:=30 probability_th:="0.3"
+  ```
 
 ## published topics
   object_analytics/rgb ([sensor_msgs::Image](http://docs.ros.org/api/sensor_msgs/html/msg/Image.html))
@@ -136,23 +141,6 @@ OA keeps integrating with various "state-of-the-art" algorithms.
   Steps to enable visualization on RViz are as following
   ```bash
   roslaunch object_analytics_visualization rviz.launch
-  ```
-
-## rostest
-  The roslaunch files with ".test" surfix will launch the test node and all dependents, including camera, detection nodelet, and object_analytics.
-  * run tracking test without visual outputs
-  ```bash
-  catkin_make
-  rostest object_analytics_nodelet mtest_tracking.test
-  ```
-  * run tracking test with visual outputs
-  ```bash
-  catkin_make clean --pkg object_analytics_nodelet
-  catkin_make -DMTEST_TRACKING_ENABLE_VIEW=ON --pkg object_analytics_nodelet
-  # to launch the test with "camera" option, to specify RGB-D camera [realsense(default)|astra]
-  rostest object_analytics_nodelet mtest_tracking.test camera:=realsense
-  # to launch the test with "detect_pkg" option, to specify detection package [movidius_ncs(default)|opencl_caffe]
-  rostest object_analytics_nodelet mtest_tracking.test detect_pkg:=movidius_ncs
   ```
 
 ###### *Any security issue should be reported using process at https://01.org/security*

--- a/object_analytics_launch/launch/analytics_movidius_ncs.launch
+++ b/object_analytics_launch/launch/analytics_movidius_ncs.launch
@@ -16,20 +16,20 @@ limitations under the License.
 <launch>
   <arg name="namespace"                     default="object_analytics" />
   <arg name="manager"                       default="ObjectAnalyticsMgr" />
-  <arg name="splitter_name"                 default="splitter" />
-  <arg name="segmenter_name"                default="segmenter" />
-  <arg name="merger_name"                   default="merger" />
-  <arg name="tracker_name"                  default="tracker" />
   <arg name="input_points"                  default="/camera/depth_registered/points"
-            doc="point cloud topic from sensor" />
+            doc="point cloud topic from rgbd sensor" />
   <arg name="input_rgb"                     default="rgb"
-            doc="rgb topic from sensor" />
+            doc="rgb topic from splitter" />
   <arg name="input_detection"               default="detection"
-            doc="detection topic from object detection nodelet" />
+            doc="detection result topic from object detection nodelet" />
   <arg name="output_localization"           default="localization"
             doc="localization result topic" />
   <arg name="output_tracking"               default="tracking"
             doc="tracking result topic" />
+  <arg name="aging_th"                      default="30"
+            doc="tracking aging threshold" />
+  <arg name="probability_th"                default="0.4"
+            doc="tracking object probability threshold" />
 
   <group ns="$(arg namespace)">
       <include file="$(find object_analytics_launch)/launch/includes/manager.launch">
@@ -37,31 +37,15 @@ limitations under the License.
           <arg name="num_worker_threads"        value="6" />
       </include>
 
-      <include file="$(find object_analytics_launch)/launch/includes/splitter.launch">
+      <include file="$(find object_analytics_launch)/launch/includes/nodelet.launch.xml">
           <arg name="manager"                   value="$(arg manager)" />
-          <arg name="name"                      value="$(arg splitter_name)" />
-          <arg name="input"                     value="$(arg input_points)" />
-          <arg name="output_2d"                 value="$(arg input_rgb)" />
-      </include>
-
-      <include file="$(find object_analytics_launch)/launch/includes/segmenter.launch">
-          <arg name="manager"                   value="$(arg manager)" />
-          <arg name="name"                      value="$(arg segmenter_name)" />
-      </include>
-
-      <include file="$(find object_analytics_launch)/launch/includes/merger.launch">
-          <arg name="manager"                   value="$(arg manager)" />
-          <arg name="name"                      value="$(arg merger_name)" />
-          <arg name="input_2d"                  value="$(arg input_detection)" />
-          <arg name="output"                    value="$(arg output_localization)" />
-      </include>
-
-      <include file="$(find object_analytics_launch)/launch/includes/tracker.launch">
-          <arg name="manager"                   value="$(arg manager)" />
-          <arg name="name"                      value="$(arg tracker_name)" />
+          <arg name="input_points"              value="$(arg input_points)" />
           <arg name="input_rgb"                 value="$(arg input_rgb)" />
-          <arg name="input_2d"                  value="$(arg input_detection)" />
-          <arg name="output"                    value="$(arg output_tracking)" />
+          <arg name="input_detection"           value="$(arg input_detection)" />
+          <arg name="output_localization"       value="$(arg output_localization)" />
+          <arg name="output_tracking"           value="$(arg output_tracking)" />
+          <arg name="aging_th"                  value="$(arg aging_th)" />
+          <arg name="probability_th"            value="$(arg probability_th)" />
       </include>
 
       <include file="$(find movidius_ncs_launch)/launch/includes/ncs_stream_detection.launch">

--- a/object_analytics_launch/launch/analytics_opencl_caffe.launch
+++ b/object_analytics_launch/launch/analytics_opencl_caffe.launch
@@ -16,21 +16,20 @@ limitations under the License.
 <launch>
   <arg name="namespace"                     default="object_analytics" />
   <arg name="manager"                       default="ObjectAnalyticsMgr" />
-  <arg name="splitter_name"                 default="splitter" />
-  <arg name="segmenter_name"                default="segmenter" />
-  <arg name="detecter_name"                 default="detecter" />
-  <arg name="merger_name"                   default="merger" />
-  <arg name="tracker_name"                  default="tracker" />
   <arg name="input_points"                  default="/camera/depth_registered/points"
-            doc="point cloud topic from sensor" />
+            doc="point cloud topic from rgbd sensor" />
   <arg name="input_rgb"                     default="rgb"
-            doc="rgb topic from sensor" />
+            doc="rgb topic from splitter" />
   <arg name="input_detection"               default="detection"
-            doc="detection topic from object detection nodelet" />
+            doc="detection result topic from object detection nodelet" />
   <arg name="output_localization"           default="localization"
             doc="localization result topic" />
   <arg name="output_tracking"               default="tracking"
             doc="tracking result topic" />
+  <arg name="aging_th"                      default="30"
+            doc="tracking aging threshold" />
+  <arg name="probability_th"                default="0.4"
+            doc="tracking object probability threshold" />
 
   <group ns="$(arg namespace)">
       <include file="$(find object_analytics_launch)/launch/includes/manager.launch">
@@ -38,36 +37,20 @@ limitations under the License.
           <arg name="num_worker_threads"        value="6" />
       </include>
 
-      <include file="$(find object_analytics_launch)/launch/includes/splitter.launch">
+      <include file="$(find object_analytics_launch)/launch/includes/nodelet.launch.xml">
           <arg name="manager"                   value="$(arg manager)" />
-          <arg name="name"                      value="$(arg splitter_name)" />
-          <arg name="input"                     value="$(arg input_points)" />
-          <arg name="output_2d"                 value="$(arg input_rgb)" />
-      </include>
-
-      <include file="$(find object_analytics_launch)/launch/includes/segmenter.launch">
-          <arg name="manager"                   value="$(arg manager)" />
-          <arg name="name"                      value="$(arg segmenter_name)" />
-      </include>
-
-      <include file="$(find object_analytics_launch)/launch/includes/merger.launch">
-          <arg name="manager"                   value="$(arg manager)" />
-          <arg name="name"                      value="$(arg merger_name)" />
-          <arg name="input_2d"                  value="$(arg input_detection)" />
-          <arg name="output"                    value="$(arg output_localization)" />
-      </include>
-
-      <include file="$(find object_analytics_launch)/launch/includes/tracker.launch">
-          <arg name="manager"                   value="$(arg manager)" />
-          <arg name="name"                      value="$(arg tracker_name)" />
+          <arg name="input_points"              value="$(arg input_points)" />
           <arg name="input_rgb"                 value="$(arg input_rgb)" />
-          <arg name="input_2d"                  value="$(arg input_detection)" />
-          <arg name="output"                    value="$(arg output_tracking)" />
+          <arg name="input_detection"           value="$(arg input_detection)" />
+          <arg name="output_localization"       value="$(arg output_localization)" />
+          <arg name="output_tracking"           value="$(arg output_tracking)" />
+          <arg name="aging_th"                  value="$(arg aging_th)" />
+          <arg name="probability_th"            value="$(arg probability_th)" />
       </include>
 
       <include file="$(find opencl_caffe_launch)/launch/includes/nodelet.launch">
           <arg name="manager"                   value="$(arg manager)" />
-          <arg name="name"                      value="$(arg detecter_name)" />
+          <arg name="name"                      value="detecter" />
           <arg name="input_topic"               value="$(arg input_rgb)" />
           <arg name="output_topic"              value="$(arg input_detection)" />
       </include>

--- a/object_analytics_launch/launch/includes/nodelet.launch.xml
+++ b/object_analytics_launch/launch/includes/nodelet.launch.xml
@@ -1,0 +1,74 @@
+<!--
+Copyright (c) 2018 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<launch>
+  <arg name="namespace"                     default="object_analytics" />
+  <arg name="manager"                       default="ObjectAnalyticsMgr" />
+  <arg name="splitter_name"                 default="splitter" />
+  <arg name="segmenter_name"                default="segmenter" />
+  <arg name="merger_name"                   default="merger" />
+  <arg name="tracker_name"                  default="tracker" />
+  <arg name="input_points"                  default="/camera/depth_registered/points"
+            doc="point cloud topic from rgbd sensor" />
+  <arg name="input_rgb"                     default="rgb"
+            doc="rgb topic from splitter" />
+  <arg name="input_pcl"                     default="pointcloud"
+            doc="pcl topic from splitter" />
+  <arg name="input_detection"               default="detection"
+            doc="detection result topic from object detection nodelet" />
+  <arg name="output_localization"           default="localization"
+            doc="localization result topic" />
+  <arg name="output_tracking"               default="tracking"
+            doc="tracking result topic" />
+  <arg name="enable_splitter"               default="true" />
+  <arg name="enable_localization"           default="true" />
+  <arg name="enable_tracking"               default="true" />
+  <arg name="aging_th"                      default="30"
+            doc="tracking aging threshold" />
+  <arg name="probability_th"                default="0.4"
+            doc="tracking object probability threshold" />
+
+  <include if="$(arg enable_splitter)" file="$(find object_analytics_launch)/launch/includes/splitter.launch">
+      <arg name="manager"                   value="$(arg manager)" />
+      <arg name="name"                      value="$(arg splitter_name)" />
+      <arg name="input"                     value="$(arg input_points)" />
+      <arg name="output_3d"                 value="$(arg input_pcl)" />
+      <arg name="output_2d"                 value="$(arg input_rgb)" />
+  </include>
+
+  <include if="$(arg enable_localization)" file="$(find object_analytics_launch)/launch/includes/segmenter.launch">
+      <arg name="manager"                   value="$(arg manager)" />
+      <arg name="name"                      value="$(arg segmenter_name)" />
+      <arg name="input"                     value="$(arg input_pcl)" />
+  </include>
+
+  <include if="$(arg enable_localization)" file="$(find object_analytics_launch)/launch/includes/merger.launch">
+      <arg name="manager"                   value="$(arg manager)" />
+      <arg name="name"                      value="$(arg merger_name)" />
+      <arg name="input_2d"                  value="$(arg input_detection)" />
+      <arg name="output"                    value="$(arg output_localization)" />
+  </include>
+
+  <include if="$(arg enable_tracking)" file="$(find object_analytics_launch)/launch/includes/tracker.launch">
+      <arg name="manager"                   value="$(arg manager)" />
+      <arg name="name"                      value="$(arg tracker_name)" />
+      <arg name="input_rgb"                 value="$(arg input_rgb)" />
+      <arg name="input_2d"                  value="$(arg input_detection)" />
+      <arg name="output"                    value="$(arg output_tracking)" />
+      <arg name="aging_th"                  value="$(arg aging_th)" />
+      <arg name="probability_th"            value="$(arg probability_th)" />
+  </include>
+
+</launch>

--- a/object_analytics_nodelet/src/tracker/tracking_manager.cpp
+++ b/object_analytics_nodelet/src/tracker/tracking_manager.cpp
@@ -33,7 +33,7 @@ namespace tracker
 
 const int32_t TrackingManager::kAgeingThreshold = 30;
 const float TrackingManager::kMatchThreshold = 0;
-const int32_t TrackingManager::kNumOfThread = 3;
+const int32_t TrackingManager::kNumOfThread = 4;
 const float TrackingManager::kProbabilityThreshold = 0.4;
 const int32_t TrackingManager::kSamplerInputRadius = 3;
 int32_t TrackingManager::tracking_cnt = 0;


### PR DESCRIPTION
The common launch file manage OA nodelets only:
- splitter
- segmenter
- merger
- tracker
It is configurable to en/disable the nodelets in terms of features.

"nodelet.launch.xml" provides the maximum flexibility to configure:
args, remaps, nodelets, etc. User can write his own launch file based
on this, taking the existing launch files as examples
(movidius_ncs.launch and opencl_caffe.launch)

Signed-off-by: Sharron LIU <sharron.liu@intel.com>