### PR TITLE
Use proper rosdep key for opencv2

### DIFF
--- a/object_analytics_visualization/CMakeLists.txt
+++ b/object_analytics_visualization/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS object_analytics_msgs object_msgs visualization_msgs rospy cv_bridge opencv2
+  CATKIN_DEPENDS object_analytics_msgs object_msgs visualization_msgs rospy cv_bridge libopencv-contrib-dev libopencv-dev
 )
 
 install(PROGRAMS

--- a/object_analytics_visualization/package.xml
+++ b/object_analytics_visualization/package.xml
@@ -31,7 +31,8 @@ limitations under the License.
   <build_depend>rospy</build_depend>
   <build_depend>visualization_msgs</build_depend>
   <build_depend>cv_bridge</build_depend>
-  <build_depend>opencv2</build_depend>
+  <build_depend>libopencv-contrib-dev</build_depend>
+  <build_depend>libopencv-dev</build_depend>
   <build_depend>roslaunch</build_depend>
 
   <run_depend>object_analytics_msgs</run_depend>
@@ -39,7 +40,8 @@ limitations under the License.
   <run_depend>rospy</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>cv_bridge</run_depend>
-  <run_depend>opencv2</run_depend>
+  <run_depend>libopencv-contrib-dev</run_depend>
+  <run_depend>libopencv-dev</run_depend>
   <run_depend>roslaunch</run_depend>
   <run_depend>rviz</run_depend>
 </package>


### PR DESCRIPTION
Fix #65 via [the correct dependency name in rosdep](https://github.com/ros/rosdistro/blob/911e3015195140e9151d3299bbe12a2b2f4dff15/rosdep/base.yaml#L3935-L3952).

